### PR TITLE
Fix filter detection logic

### DIFF
--- a/src/lib/hooks/useGrantSearch.ts
+++ b/src/lib/hooks/useGrantSearch.ts
@@ -66,7 +66,15 @@ export function useGrantSearch() {
     handlePageChange,
     
     // Computed
-    hasActiveFilters: Object.values(searchFilters).some(value => value !== ''),
+    hasActiveFilters:
+      searchFilters.textSearch !== '' ||
+      searchFilters.minFunding !== '' ||
+      searchFilters.maxFunding !== '' ||
+      searchFilters.minDeadline !== '' ||
+      searchFilters.maxDeadline !== '' ||
+      searchFilters.minFitScore !== '' ||
+      searchFilters.maxFitScore !== '' ||
+      (searchFilters.source && searchFilters.source !== 'ALL'),
     resultsCount: pagination?.total ?? 0,
     pagination,
   };


### PR DESCRIPTION
## Summary
- fix logic for checking if filters are active in `useGrantSearch`

## Testing
- `pnpm install`
- `npm run lint` *(fails: many existing errors in generated files)*

------
https://chatgpt.com/codex/tasks/task_e_687a7b729a548326af599265a9e65a77