### PR TITLE
Add Google Analytics (G-XNXC2ZKSDF)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,6 +10,7 @@ import { Header } from '@/components/layout/Header';
 import { getServerSession } from 'next-auth';
 import { Analytics } from '@vercel/analytics/next';
 import { ProfileSetupToast } from '@/components/onboarding/profile-setup-toast';
+import Script from 'next/script';
 
 export const metadata: Metadata = {
 	title: 'AI GrantMatch',
@@ -98,6 +99,18 @@ export default async function RootLayout({
 					<Toaster position="top-center" />
 				</NextAuthProvider>
 				<Analytics />
+				<Script
+					src="https://www.googletagmanager.com/gtag/js?id=G-XNXC2ZKSDF"
+					strategy="afterInteractive"
+				/>
+				<Script id="google-analytics" strategy="afterInteractive">
+					{`
+						window.dataLayer = window.dataLayer || [];
+						function gtag(){dataLayer.push(arguments);}
+						gtag('js', new Date());
+						gtag('config', 'G-XNXC2ZKSDF');
+					`}
+				</Script>
 			</body>
 		</html>
 	);


### PR DESCRIPTION
## Summary
- Adds Google Analytics tracking to the site using the Next.js `Script` component with `afterInteractive` strategy
- Loads the gtag.js script from Google Tag Manager and initializes the GA4 measurement ID `G-XNXC2ZKSDF`

## Test plan
- [ ] Deploy and verify GA events appear in the Google Analytics dashboard
- [ ] Confirm no blocking of page render (script loads after interactive)

🤖 Generated with [Claude Code](https://claude.com/claude-code)