### PR TITLE
fix: source NVM in conductor.json to use correct Node.js version

### DIFF
--- a/conductor.json
+++ b/conductor.json
@@ -1,7 +1,7 @@
 {
     "scripts": {
-        "setup": "cp $CONDUCTOR_ROOT_PATH/.env .env && pnpm install",
-        "run": "./start-database.sh && pnpm prisma migrate dev && pnpm prisma generate && pnpm dev",
+        "setup": "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use 24.7.0 && cp $CONDUCTOR_ROOT_PATH/.env .env && pnpm install",
+        "run": "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use 24.7.0 && ./start-database.sh && pnpm prisma migrate dev && pnpm prisma generate && pnpm dev",
         "archive": ""
     }
 }


### PR DESCRIPTION
## Summary
- Sources NVM and explicitly sets Node.js v24.7.0 in both the `setup` and `run` scripts in `conductor.json`
- Fixes workspace setup failures where Prisma 7's preinstall check rejected the system Node (v22.5.0), which doesn't meet its 20.19+/22.12+/24.0+ requirement

## Test plan
- [ ] Re-run Conductor workspace setup and confirm it completes without the Prisma preinstall error

🤖 Generated with [Claude Code](https://claude.com/claude-code)