### PR TITLE
fix: use www subdomain in sitemap base URL

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,7 +2,7 @@ import type { MetadataRoute } from 'next';
 import { getIndexableGrantIds } from '@/lib/public-grants';
 
 const BASE_URL =
-	process.env.NEXT_PUBLIC_APP_URL ?? 'https://aigrantmatch.com';
+	process.env.NEXT_PUBLIC_APP_URL ?? 'https://www.aigrantmatch.com';
 
 const STATIC_ROUTES = ['/', '/about', '/grants', '/privacy', '/terms', '/contact'];
 


### PR DESCRIPTION
## Summary
- Updated the sitemap fallback `BASE_URL` from `https://aigrantmatch.com` to `https://www.aigrantmatch.com` to match the canonical domain the site redirects to.

## Test plan
- [ ] Verify `/sitemap.xml` in production returns URLs with `www.aigrantmatch.com`
- [ ] Confirm `NEXT_PUBLIC_APP_URL` env var in Vercel is also set to `https://www.aigrantmatch.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)